### PR TITLE
Fix duplicate parameter

### DIFF
--- a/fbuffer.h
+++ b/fbuffer.h
@@ -20,4 +20,4 @@ void fb_bitblt(u8 *sprite, u16 x, u16 y, u8 frame);
 void fb_blank();
 
 //! Draw a horizontal line.
-void fb_horizline(u16 x, u16 y, u16 x);
+void fb_horizline(u16 x, u16 y, u16 xp);


### PR DESCRIPTION
I was receiving the following error when running the command: **make opensesame.rel**

**fbuffer.h:23: error 249: duplicate parameter name x for function fb_horizline**

So to fix this error, I rename the last parameter in the fb_horizline function.