### PR TITLE
Fix rolling codes bug: reset k in de_bruijn() initialization

### DIFF
--- a/rf.c
+++ b/rf.c
@@ -135,10 +135,11 @@ void convert_bits()
 // start the de bruijn sequence using the recursive db() function
 void de_bruijn()
 {
-	// clear a[], s
+	// clear a[], s, k
 	for (tmpi = 0; tmpi <= MAXBITS; tmpi++)
 		a[tmpi] = 0;
 	s = 0;
+	k = 0;
 	firstTx = 1;
 
 	// begin recursive de bruijn


### PR DESCRIPTION
The global variable k was not being reset to 0 in de_bruijn(), causing subsequent garage runs to skip the first `bits` codes of the De Bruijn sequence. This broke the De Bruijn property and prevented some codes from ever being transmitted for the second+ garage in the cycle, or on any re-run of the main loop.

https://claude.ai/code/session_01CJR7v3PssznU96Q74wufVB